### PR TITLE
Make swipe down show swipe left animation

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -239,7 +239,7 @@ void DisplayApp::Refresh() {
                 LoadApp(Apps::Clock, DisplayApp::FullRefreshDirections::RightAnim);
                 break;
               case TouchEvents::SwipeDown:
-                LoadApp(Apps::Clock, DisplayApp::FullRefreshDirections::Down);
+                LoadApp(Apps::Clock, DisplayApp::FullRefreshDirections::RightAnim);
                 break;
             }
           } else if (currentApp == Apps::QuickSettings) {


### PR DESCRIPTION
When the quick settings are swiped down on the swipe left animation is played, so the music app should show the swipe right animation to keep it consistent